### PR TITLE
Fires `dndstart` when traveler is created.

### DIFF
--- a/test/list-test.js
+++ b/test/list-test.js
@@ -148,17 +148,21 @@ test('fires dnd events', function (t) {
     calls++
   })
 
-
   trigger(li, 'mousedown')
   trigger(li, 'mousemove')
   trigger(window, 'keydown', {
     keyCode: 27
   })
   trigger(li, 'mousedown')
-  trigger(li, 'mouseup')
 
-  t.equal(calls, 4, '4 events emitted')
+  // Wait for the start event to trigger from create traveler callback
+  setTimeout(function () {
+    trigger(li, 'mouseup')
 
-  container.remove()
-  t.end()
+    t.equal(calls, 4, '4 events emitted')
+
+    container.remove()
+    t.end()
+  }, 350)
+
 })


### PR DESCRIPTION
Requested by @donaldjohn for
https://github.com/SpiderStrategies/Scoreboard/pull/5986. Adds a small
performance enhancement by preventing createTraveler calls on each mouse
move, which checked if a traveler was already in the dom.
